### PR TITLE
Punchblock::Event::Complete event now bubbles

### DIFF
--- a/lib/adhearsion_cpa/tone_detector.rb
+++ b/lib/adhearsion_cpa/tone_detector.rb
@@ -18,6 +18,7 @@ module AdhearsionCpa
 
         component.register_event_handler Punchblock::Event::Complete do |event|
           yield event.reason if block_given? && event.reason.is_a?(Punchblock::Component::Input::Signal)
+          throw :pass
         end
       end
 


### PR DESCRIPTION
I have a situation where I would like to detect a tone asynchronously and be made aware when it is complete, regardless of reason.  Currently, the block passed into `#detect_tones!` will only be called when a tone is detected, not for other reasons such as timing out.  Like other Punchblock commands, I should be able to register an event handler on `Punchblock::Event::Complete` that will execute upon completion, but it currently does not work because the event is not bubbling.  A simple call to `throw :pass` resolves the issue.
